### PR TITLE
fix/toast-feedback

### DIFF
--- a/src/components/confirm-dialog.tsx
+++ b/src/components/confirm-dialog.tsx
@@ -10,14 +10,14 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import { createToastCallbacks } from "./form/callbacks/toast-callbacks";
-import { withCallbacks } from "./form/callbacks/with-callbacks";
+import { useCallbacks } from "./form/callbacks/use-callbacks";
 import { ActionState, EMPTY_ACTION_STATE } from "./form/utils/to-action-state";
 import { Button } from "./ui/button";
 
 type UseConfirmDialogArgs = {
   title?: string;
   description?: string;
-  loadingMessage?: string;
+  loading?: string;
   action: () => Promise<ActionState | undefined>;
   trigger: React.ReactElement | ((isLoading: boolean) => React.ReactElement);
   onSuccess?: (actionState: ActionState | undefined) => void;
@@ -26,7 +26,7 @@ type UseConfirmDialogArgs = {
 const useConfirmDialog = ({
   title = "Are you absolutely sure?",
   description = "This action cannot be undone. Make sure you understand the consequences.",
-  loadingMessage = "Loading ...",
+  loading = "Loading ...",
   action,
   trigger,
   onSuccess,
@@ -34,10 +34,10 @@ const useConfirmDialog = ({
   const [isOpen, setIsOpen] = useState(false);
 
   const [, formAction, isPending] = useActionState(
-    withCallbacks(
+    useCallbacks(
       action,
       createToastCallbacks({
-        loadingMessage,
+        loading,
         onSuccess,
       })
     ),

--- a/src/components/confirm-dialog.tsx
+++ b/src/components/confirm-dialog.tsx
@@ -1,11 +1,4 @@
-import {
-  cloneElement,
-  useActionState,
-  useEffect,
-  useRef,
-  useState,
-} from "react";
-import { toast } from "sonner";
+import { cloneElement, useActionState, useState } from "react";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -16,29 +9,38 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
-import { useActionFeedback } from "./form/hooks/use-action-feedback";
+import { createToastCallbacks } from "./form/callbacks/toast-callbacks";
+import { withCallbacks } from "./form/callbacks/with-callbacks";
 import { ActionState, EMPTY_ACTION_STATE } from "./form/utils/to-action-state";
 import { Button } from "./ui/button";
 
 type UseConfirmDialogArgs = {
   title?: string;
   description?: string;
+  loadingMessage?: string;
   action: () => Promise<ActionState | undefined>;
   trigger: React.ReactElement | ((isLoading: boolean) => React.ReactElement);
-  onSuccess?: (actionState: ActionState) => void;
+  onSuccess?: (actionState: ActionState | undefined) => void;
 };
 
 const useConfirmDialog = ({
   title = "Are you absolutely sure?",
   description = "This action cannot be undone. Make sure you understand the consequences.",
+  loadingMessage = "Loading ...",
   action,
   trigger,
   onSuccess,
 }: UseConfirmDialogArgs) => {
   const [isOpen, setIsOpen] = useState(false);
 
-  const [actionState, formAction, isPending] = useActionState(
-    action,
+  const [, formAction, isPending] = useActionState(
+    withCallbacks(
+      action,
+      createToastCallbacks({
+        loadingMessage,
+        onSuccess,
+      })
+    ),
     EMPTY_ACTION_STATE
   );
 
@@ -48,37 +50,6 @@ const useConfirmDialog = ({
       onClick: () => setIsOpen((state) => !state),
     }
   );
-
-  const toastRef = useRef<string | number | null>(null);
-
-  useEffect(() => {
-    if (isPending) {
-      toastRef.current = toast.loading("Deleting ...");
-    } else if (toastRef.current) {
-      toast.dismiss(toastRef.current);
-    }
-
-    return () => {
-      if (toastRef.current) {
-        toast.dismiss(toastRef.current);
-      }
-    };
-  }, [isPending]);
-
-  useActionFeedback(actionState, {
-    onSuccess: ({ actionState }) => {
-      if (actionState.message) {
-        toast.success(actionState.message);
-      }
-
-      onSuccess?.(actionState);
-    },
-    onError: ({ actionState }) => {
-      if (actionState.message) {
-        toast.error(actionState.message);
-      }
-    },
-  });
 
   const dialog = (
     <AlertDialog open={isOpen} onOpenChange={setIsOpen}>

--- a/src/components/form/callbacks/toast-callbacks.ts
+++ b/src/components/form/callbacks/toast-callbacks.ts
@@ -4,15 +4,16 @@ import { ActionState } from "../utils/to-action-state";
 type Reference = string | number | undefined;
 
 type CreateToastCallbacksOptions = {
-  loadingMessage?: string;
+  loading?: string;
   onSuccess?: (actionState: ActionState) => void;
   onError?: (actionState: ActionState) => void;
+  onCleanup?: (reference: Reference) => void;
 };
 
 export const createToastCallbacks = (options: CreateToastCallbacksOptions) => {
   return {
     onLoad: () => {
-      return toast.loading(options.loadingMessage || "Loading ...");
+      return toast.loading(options.loading || "Loading ...");
     },
     onSuccess: (result: ActionState, reference: Reference) => {
       if (result?.message) {
@@ -34,6 +35,15 @@ export const createToastCallbacks = (options: CreateToastCallbacksOptions) => {
 
       if (options.onError) {
         options.onError(result);
+      }
+    },
+    onCleanup: (reference: Reference) => {
+      if (reference) {
+        toast.dismiss(reference);
+      }
+
+      if (options.onCleanup) {
+        options.onCleanup(reference);
       }
     },
   };

--- a/src/components/form/callbacks/toast-callbacks.ts
+++ b/src/components/form/callbacks/toast-callbacks.ts
@@ -1,0 +1,40 @@
+import { toast } from "sonner";
+import { ActionState } from "../utils/to-action-state";
+
+type Reference = string | number | undefined;
+
+type CreateToastCallbacksOptions = {
+  loadingMessage?: string;
+  onSuccess?: (actionState: ActionState) => void;
+  onError?: (actionState: ActionState) => void;
+};
+
+export const createToastCallbacks = (options: CreateToastCallbacksOptions) => {
+  return {
+    onLoad: () => {
+      return toast.loading(options.loadingMessage || "Loading ...");
+    },
+    onSuccess: (result: ActionState, reference: Reference) => {
+      if (result?.message) {
+        toast.success(result?.message, {
+          id: reference,
+        });
+      }
+
+      if (options.onSuccess) {
+        options.onSuccess(result);
+      }
+    },
+    onError: (result: ActionState, reference: Reference) => {
+      if (result?.message) {
+        toast.error(result?.message, {
+          id: reference,
+        });
+      }
+
+      if (options.onError) {
+        options.onError(result);
+      }
+    },
+  };
+};

--- a/src/components/form/callbacks/with-callbacks.ts
+++ b/src/components/form/callbacks/with-callbacks.ts
@@ -1,0 +1,34 @@
+import { ActionState } from "../utils/to-action-state";
+
+type Callbacks<T, R = unknown> = {
+  onLoad?: () => R;
+  onSuccess?: (result: T, reference: R | undefined) => void;
+  onError?: (result: T, reference: R | undefined) => void;
+};
+
+export const withCallbacks = <
+  Args extends unknown[],
+  T extends ActionState,
+  R = unknown
+>(
+  fn: (...args: Args) => Promise<T>,
+  callbacks: Callbacks<T, R>
+): ((...args: Args) => Promise<T>) => {
+  return async (...args: Args) => {
+    const promise = fn(...args);
+
+    const reference = callbacks.onLoad?.();
+
+    const result = await promise;
+
+    if (result?.status === "SUCCESS") {
+      callbacks.onSuccess?.(result, reference);
+    }
+
+    if (result?.status === "ERROR") {
+      callbacks.onError?.(result, reference);
+    }
+
+    return promise;
+  };
+};

--- a/src/components/form/field-error.tsx
+++ b/src/components/form/field-error.tsx
@@ -6,7 +6,7 @@ type FieldErrorProps = {
 };
 
 const FieldError = ({ actionState, name }: FieldErrorProps) => {
-  const message = actionState.fieldErrors[name]?.[0];
+  const message = actionState?.fieldErrors[name]?.[0];
 
   if (!message) return null;
 

--- a/src/components/form/form.tsx
+++ b/src/components/form/form.tsx
@@ -19,15 +19,15 @@ const Form = ({
 }: FormProps) => {
   useActionFeedback(actionState, {
     onSuccess: ({ actionState }) => {
-      if (actionState.message) {
-        toast.success(actionState.message);
+      if (actionState?.message) {
+        toast.success(actionState?.message);
       }
 
       onSuccess?.(actionState);
     },
     onError: ({ actionState }) => {
-      if (actionState.message) {
-        toast.error(actionState.message);
+      if (actionState?.message) {
+        toast.error(actionState?.message);
       }
 
       onError?.(actionState);

--- a/src/components/form/utils/to-action-state.ts
+++ b/src/components/form/utils/to-action-state.ts
@@ -1,20 +1,19 @@
 import { ZodError } from "zod";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type ActionState<T = any> = {
-  status?: "SUCCESS" | "ERROR";
-  message: string;
-  payload?: FormData;
-  fieldErrors: Record<string, string[] | undefined>;
-  timestamp: number;
-  data?: T;
-};
+export type ActionState<T = any> =
+  | {
+      status?: "SUCCESS" | "ERROR";
+      message: string;
+      payload?: FormData;
+      fieldErrors: Record<string, string[] | undefined>;
+      timestamp: number;
+      data?: T;
+    }
+  | null
+  | undefined;
 
-export const EMPTY_ACTION_STATE: ActionState = {
-  message: "",
-  fieldErrors: {},
-  timestamp: Date.now(),
-};
+export const EMPTY_ACTION_STATE: ActionState = null;
 
 export const fromErrorToActionState = (
   error: unknown,
@@ -48,7 +47,7 @@ export const fromErrorToActionState = (
 };
 
 export const toActionState = (
-  status: ActionState["status"],
+  status: "SUCCESS" | "ERROR",
   message: string,
   formData?: FormData,
   data?: unknown

--- a/src/features/auth/components/sign-in-form.tsx
+++ b/src/features/auth/components/sign-in-form.tsx
@@ -16,7 +16,7 @@ const SignInForm = () => {
       <Input
         name="email"
         placeholder="Email"
-        defaultValue={actionState.payload?.get("email") as string}
+        defaultValue={actionState?.payload?.get("email") as string}
       />
       <FieldError actionState={actionState} name="email" />
 
@@ -24,7 +24,7 @@ const SignInForm = () => {
         type="password"
         name="password"
         placeholder="Password"
-        defaultValue={actionState.payload?.get("password") as string}
+        defaultValue={actionState?.payload?.get("password") as string}
       />
       <FieldError actionState={actionState} name="password" />
 

--- a/src/features/auth/components/sign-up-form.tsx
+++ b/src/features/auth/components/sign-up-form.tsx
@@ -16,14 +16,14 @@ const SignUpForm = () => {
       <Input
         name="username"
         placeholder="Username"
-        defaultValue={actionState.payload?.get("username") as string}
+        defaultValue={actionState?.payload?.get("username") as string}
       />
       <FieldError actionState={actionState} name="username" />
 
       <Input
         name="email"
         placeholder="Email"
-        defaultValue={actionState.payload?.get("email") as string}
+        defaultValue={actionState?.payload?.get("email") as string}
       />
       <FieldError actionState={actionState} name="email" />
 
@@ -31,7 +31,7 @@ const SignUpForm = () => {
         type="password"
         name="password"
         placeholder="Password"
-        defaultValue={actionState.payload?.get("password") as string}
+        defaultValue={actionState?.payload?.get("password") as string}
       />
       <FieldError actionState={actionState} name="password" />
 
@@ -39,7 +39,7 @@ const SignUpForm = () => {
         type="password"
         name="confirmPassword"
         placeholder="Confirm Password"
-        defaultValue={actionState.payload?.get("confirmPassword") as string}
+        defaultValue={actionState?.payload?.get("confirmPassword") as string}
       />
       <FieldError actionState={actionState} name="confirmPassword" />
 

--- a/src/features/comment/components/comment-create-form.tsx
+++ b/src/features/comment/components/comment-create-form.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { useActionState } from "react";
+import { createToastCallbacks } from "@/components/form/callbacks/toast-callbacks";
+import { useCallbacks } from "@/components/form/callbacks/use-callbacks";
 import { FieldError } from "@/components/form/field-error";
-import { Form } from "@/components/form/form";
 import { SubmitButton } from "@/components/form/submit-button";
 import {
   ActionState,
@@ -23,19 +24,25 @@ const CommentCreateForm = ({
   ticketId,
   onCreateComment,
 }: CommentCreateFormProps) => {
-  const [actionState, action] = useActionState(
-    createComment.bind(null, ticketId),
-    EMPTY_ACTION_STATE
-  );
-
   const handleSuccess = (
     actionState: ActionState<CommentWithMetadata | undefined>
   ) => {
     onCreateComment?.(actionState?.data);
   };
 
+  const [actionState, action] = useActionState(
+    useCallbacks(
+      createComment.bind(null, ticketId),
+      createToastCallbacks({
+        loading: "Creating comment...",
+        onSuccess: handleSuccess,
+      })
+    ),
+    EMPTY_ACTION_STATE
+  );
+
   return (
-    <Form action={action} actionState={actionState} onSuccess={handleSuccess}>
+    <form action={action} className="flex flex-col gap-y-2">
       <Textarea name="content" placeholder="What's on your mind ..." />
       <FieldError actionState={actionState} name="content" />
 
@@ -49,7 +56,7 @@ const CommentCreateForm = ({
       <FieldError actionState={actionState} name="files" />
 
       <SubmitButton label="Comment" />
-    </Form>
+    </form>
   );
 };
 

--- a/src/features/comment/components/comment-create-form.tsx
+++ b/src/features/comment/components/comment-create-form.tsx
@@ -31,7 +31,7 @@ const CommentCreateForm = ({
   const handleSuccess = (
     actionState: ActionState<CommentWithMetadata | undefined>
   ) => {
-    onCreateComment?.(actionState.data);
+    onCreateComment?.(actionState?.data);
   };
 
   return (

--- a/src/features/comment/components/comment-delete-button.tsx
+++ b/src/features/comment/components/comment-delete-button.tsx
@@ -16,6 +16,7 @@ const CommentDeleteButton = ({
 }: CommentDeleteButtonProps) => {
   const [deleteButton, deleteDialog] = useConfirmDialog({
     action: deleteComment.bind(null, id),
+    loading: "Deleting comment...",
     trigger: (isPending) => (
       <Button variant="outline" size="icon">
         {isPending ? (

--- a/src/features/membership/components/membership-more-menu.tsx
+++ b/src/features/membership/components/membership-more-menu.tsx
@@ -39,10 +39,10 @@ const MembershipMoreMenu = ({
 
     const result = await promise;
 
-    if (result.status === "ERROR") {
-      toast.error(result.message);
+    if (result?.status === "ERROR") {
+      toast.error(result?.message);
     } else {
-      toast.success(result.message);
+      toast.success(result?.message);
     }
   };
 

--- a/src/features/organization/components/organization-create-form.tsx
+++ b/src/features/organization/components/organization-create-form.tsx
@@ -19,7 +19,7 @@ const OrganizationCreateForm = () => {
       <Input
         name="name"
         placeholder="Name"
-        defaultValue={actionState.payload?.get("name") as string}
+        defaultValue={actionState?.payload?.get("name") as string}
       />
       <FieldError actionState={actionState} name="name" />
 

--- a/src/features/password/components/password-change-form.tsx
+++ b/src/features/password/components/password-change-form.tsx
@@ -20,7 +20,7 @@ const PasswordChangeForm = () => {
         type="password"
         name="password"
         placeholder="Password"
-        defaultValue={actionState.payload?.get("password") as string}
+        defaultValue={actionState?.payload?.get("password") as string}
       />
       <FieldError actionState={actionState} name="password" />
 

--- a/src/features/password/components/password-forgot-form.tsx
+++ b/src/features/password/components/password-forgot-form.tsx
@@ -19,7 +19,7 @@ const PasswordForgotForm = () => {
       <Input
         name="email"
         placeholder="Email"
-        defaultValue={actionState.payload?.get("email") as string}
+        defaultValue={actionState?.payload?.get("email") as string}
       />
       <FieldError actionState={actionState} name="email" />
 

--- a/src/features/password/components/password-reset-form.tsx
+++ b/src/features/password/components/password-reset-form.tsx
@@ -24,7 +24,7 @@ const PasswordResetForm = ({ tokenId }: PasswordResetFormProps) => {
         type="password"
         name="password"
         placeholder="Password"
-        defaultValue={actionState.payload?.get("password") as string}
+        defaultValue={actionState?.payload?.get("password") as string}
       />
       <FieldError actionState={actionState} name="password" />
 
@@ -32,7 +32,7 @@ const PasswordResetForm = ({ tokenId }: PasswordResetFormProps) => {
         type="password"
         name="confirmPassword"
         placeholder="Confirm Password"
-        defaultValue={actionState.payload?.get("confirmPassword") as string}
+        defaultValue={actionState?.payload?.get("confirmPassword") as string}
       />
       <FieldError actionState={actionState} name="confirmPassword" />
 

--- a/src/features/ticket/components/ticket-more-menu.tsx
+++ b/src/features/ticket/components/ticket-more-menu.tsx
@@ -26,6 +26,7 @@ type TicketMoreMenuProps = {
 const TicketMoreMenu = ({ ticket, trigger }: TicketMoreMenuProps) => {
   const [deleteButton, deleteDialog] = useConfirmDialog({
     action: deleteTicket.bind(null, ticket.id),
+    loading: "Deleting ticket...",
     trigger: (
       <DropdownMenuItem disabled={!ticket.permissions.canDeleteTicket}>
         <LucideTrash className="h-4 w-4" />

--- a/src/features/ticket/components/ticket-more-menu.tsx
+++ b/src/features/ticket/components/ticket-more-menu.tsx
@@ -43,10 +43,10 @@ const TicketMoreMenu = ({ ticket, trigger }: TicketMoreMenuProps) => {
 
     const result = await promise;
 
-    if (result.status === "ERROR") {
-      toast.error(result.message);
-    } else if (result.status === "SUCCESS") {
-      toast.success(result.message);
+    if (result?.status === "ERROR") {
+      toast.error(result?.message);
+    } else if (result?.status === "SUCCESS") {
+      toast.success(result?.message);
     }
   };
 

--- a/src/features/ticket/components/ticket-upsert-form.tsx
+++ b/src/features/ticket/components/ticket-upsert-form.tsx
@@ -7,7 +7,7 @@ import {
   ImperativeHandleFromDatePicker,
 } from "@/components/date-picker";
 import { createToastCallbacks } from "@/components/form/callbacks/toast-callbacks";
-import { withCallbacks } from "@/components/form/callbacks/with-callbacks";
+import { useCallbacks } from "@/components/form/callbacks/use-callbacks";
 import { FieldError } from "@/components/form/field-error";
 import { SubmitButton } from "@/components/form/submit-button";
 import { EMPTY_ACTION_STATE } from "@/components/form/utils/to-action-state";
@@ -26,10 +26,10 @@ const TicketUpsertForm = ({ ticket }: TicketUpsertFormProps) => {
     useRef<ImperativeHandleFromDatePicker>(null);
 
   const [actionState, action] = useActionState(
-    withCallbacks(
+    useCallbacks(
       upsertTicket.bind(null, ticket?.id),
       createToastCallbacks({
-        loadingMessage: ticket ? "Editing ticket..." : "Creating ticket...",
+        loading: ticket ? "Updating ticket..." : "Creating ticket...",
         onSuccess: () => datePickerImperativeHandleRef.current?.reset(),
       })
     ),

--- a/src/features/ticket/components/ticket-upsert-form.tsx
+++ b/src/features/ticket/components/ticket-upsert-form.tsx
@@ -17,22 +17,6 @@ import { Textarea } from "@/components/ui/textarea";
 import { fromCent } from "@/utils/currency";
 import { upsertTicket } from "../actions/upsert-ticket";
 
-const useTicketUpsert = (
-  ticket: Ticket | undefined,
-  options: { onSuccess: () => void }
-) => {
-  return useActionState(
-    withCallbacks(
-      upsertTicket.bind(null, ticket?.id),
-      createToastCallbacks({
-        loadingMessage: ticket ? "Editing ticket..." : "Creating ticket...",
-        onSuccess: options.onSuccess,
-      })
-    ),
-    EMPTY_ACTION_STATE
-  );
-};
-
 type TicketUpsertFormProps = {
   ticket?: Ticket;
 };
@@ -41,9 +25,16 @@ const TicketUpsertForm = ({ ticket }: TicketUpsertFormProps) => {
   const datePickerImperativeHandleRef =
     useRef<ImperativeHandleFromDatePicker>(null);
 
-  const [actionState, action] = useTicketUpsert(ticket, {
-    onSuccess: () => datePickerImperativeHandleRef.current?.reset(),
-  });
+  const [actionState, action] = useActionState(
+    withCallbacks(
+      upsertTicket.bind(null, ticket?.id),
+      createToastCallbacks({
+        loadingMessage: ticket ? "Editing ticket..." : "Creating ticket...",
+        onSuccess: () => datePickerImperativeHandleRef.current?.reset(),
+      })
+    ),
+    EMPTY_ACTION_STATE
+  );
 
   return (
     <form action={action} className="flex flex-col gap-y-2">

--- a/src/features/ticket/components/ticket-upsert-form.tsx
+++ b/src/features/ticket/components/ticket-upsert-form.tsx
@@ -41,7 +41,7 @@ const TicketUpsertForm = ({ ticket }: TicketUpsertFormProps) => {
         name="title"
         type="text"
         defaultValue={
-          (actionState.payload?.get("title") as string) ?? ticket?.title
+          (actionState?.payload?.get("title") as string) ?? ticket?.title
         }
       />
       <FieldError actionState={actionState} name="title" />
@@ -51,7 +51,7 @@ const TicketUpsertForm = ({ ticket }: TicketUpsertFormProps) => {
         id="content"
         name="content"
         defaultValue={
-          (actionState.payload?.get("content") as string) ?? ticket?.content
+          (actionState?.payload?.get("content") as string) ?? ticket?.content
         }
       />
       <FieldError actionState={actionState} name="content" />
@@ -63,7 +63,7 @@ const TicketUpsertForm = ({ ticket }: TicketUpsertFormProps) => {
             id="deadline"
             name="deadline"
             defaultValue={
-              (actionState.payload?.get("deadline") as string) ??
+              (actionState?.payload?.get("deadline") as string) ??
               ticket?.deadline
             }
             imperativeHandleRef={datePickerImperativeHandleRef}
@@ -78,7 +78,7 @@ const TicketUpsertForm = ({ ticket }: TicketUpsertFormProps) => {
             type="number"
             step=".01"
             defaultValue={
-              (actionState.payload?.get("bounty") as string) ??
+              (actionState?.payload?.get("bounty") as string) ??
               (ticket?.bounty ? fromCent(ticket?.bounty) : "")
             }
           />

--- a/src/features/ticket/components/ticket-upsert-form.tsx
+++ b/src/features/ticket/components/ticket-upsert-form.tsx
@@ -6,8 +6,9 @@ import {
   DatePicker,
   ImperativeHandleFromDatePicker,
 } from "@/components/date-picker";
+import { createToastCallbacks } from "@/components/form/callbacks/toast-callbacks";
+import { withCallbacks } from "@/components/form/callbacks/with-callbacks";
 import { FieldError } from "@/components/form/field-error";
-import { Form } from "@/components/form/form";
 import { SubmitButton } from "@/components/form/submit-button";
 import { EMPTY_ACTION_STATE } from "@/components/form/utils/to-action-state";
 import { Input } from "@/components/ui/input";
@@ -16,25 +17,36 @@ import { Textarea } from "@/components/ui/textarea";
 import { fromCent } from "@/utils/currency";
 import { upsertTicket } from "../actions/upsert-ticket";
 
+const useTicketUpsert = (
+  ticket: Ticket | undefined,
+  options: { onSuccess: () => void }
+) => {
+  return useActionState(
+    withCallbacks(
+      upsertTicket.bind(null, ticket?.id),
+      createToastCallbacks({
+        loadingMessage: ticket ? "Editing ticket..." : "Creating ticket...",
+        onSuccess: options.onSuccess,
+      })
+    ),
+    EMPTY_ACTION_STATE
+  );
+};
+
 type TicketUpsertFormProps = {
   ticket?: Ticket;
 };
 
 const TicketUpsertForm = ({ ticket }: TicketUpsertFormProps) => {
-  const [actionState, action] = useActionState(
-    upsertTicket.bind(null, ticket?.id),
-    EMPTY_ACTION_STATE
-  );
-
   const datePickerImperativeHandleRef =
     useRef<ImperativeHandleFromDatePicker>(null);
 
-  const handleSuccess = () => {
-    datePickerImperativeHandleRef.current?.reset();
-  };
+  const [actionState, action] = useTicketUpsert(ticket, {
+    onSuccess: () => datePickerImperativeHandleRef.current?.reset(),
+  });
 
   return (
-    <Form action={action} actionState={actionState} onSuccess={handleSuccess}>
+    <form action={action} className="flex flex-col gap-y-2">
       <Label htmlFor="title">Title</Label>
       <Input
         id="title"
@@ -87,7 +99,7 @@ const TicketUpsertForm = ({ ticket }: TicketUpsertFormProps) => {
       </div>
 
       <SubmitButton label={ticket ? "Edit" : "Create"} />
-    </Form>
+    </form>
   );
 };
 


### PR DESCRIPTION
- [x] do not rely on custom Form component with its useActionFeedback
- [x] instead use new `useCallbacks` hook with  `toastCallbacks` helper function
- [x] also allows to remove useActionFeedback from useConfirmDialog

Benefits:

- when deleting an entity in a server action where the component gets unmounted due to cahce invaldiation, we were not able to show a toast notification for the successful operation (due to unmounting component and useEffect no longer kicking in)
- we do not rely on the component lifecycle anymore, but only on callback functions on the action
- we can pass in the loadign state from the outside
- loading toast gets replaced by success/error toast